### PR TITLE
Added more handling for null references.

### DIFF
--- a/Core/TcpClientSession.cs
+++ b/Core/TcpClientSession.cs
@@ -205,21 +205,20 @@ namespace SuperSocket.ClientEngine
                 m_IsSending = 0;
             }
 
-            if (client.Connected)
+            try
+            {
+                client.Shutdown(SocketShutdown.Both);
+            }
+            catch
+            {}
+            finally
             {
                 try
                 {
-                    client.Shutdown(SocketShutdown.Both);
+                    client.Close();
                 }
-                catch { }
-                finally
-                {
-                    try
-                    {
-                        client.Close();
-                    }
-                    catch {}
-                }
+                catch
+                {}
             }
 
             return fireOnClosedEvent;


### PR DESCRIPTION
During testing we found that NullReference exceptions could occur during async callbacks. This is an attempt to resolve those issues. I also made changes to clean up the SSL stream on close. In our testing we've eliminated the NullReference exceptions when using SSL & TCP sessions.
