### PR TITLE
Updates to build with the latest versions of Xamarin tools

### DIFF
--- a/Common/Common.MonoDroid.csproj
+++ b/Common/Common.MonoDroid.csproj
@@ -8,14 +8,14 @@
     <ProjectGuid>{38367EC0-D72E-4EC5-8FBA-0AE3706A2C49}</ProjectGuid>
     <ProjectTypeGuids>{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SuperSocket.ClientEngine</RootNamespace>
     <AssemblyName>SuperSocket.ClientEngine.Common</AssemblyName>
-    <FileAlignment>512</FileAlignment>
-    <AndroidApplication>true</AndroidApplication>
-    <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
+    <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
+    <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
+    <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
+    <AndroidResgenClass>Resource</AndroidResgenClass>
     <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
+    <TargetFrameworkVersion>v2.3</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -26,7 +26,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AndroidLinkMode>None</AndroidLinkMode>
-    <EmbedAssembliesIntoApk>False</EmbedAssembliesIntoApk>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -68,7 +67,4 @@
   <Target Name="AfterBuild">
   </Target>
   -->
-  <ItemGroup>
-    <None Include="Properties\AndroidManifest.xml" />
-  </ItemGroup>
 </Project>

--- a/Common/Properties/AndroidManifest.xml
+++ b/Common/Properties/AndroidManifest.xml
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="Common.MonoDroid">
-	<uses-sdk />
-	<application android:label="Common.MonoDroid"></application>
-</manifest>

--- a/Core/Core.MonoDroid.csproj
+++ b/Core/Core.MonoDroid.csproj
@@ -8,14 +8,14 @@
     <ProjectGuid>{6447CAEB-757A-4D47-91BA-71E521AA7B42}</ProjectGuid>
     <ProjectTypeGuids>{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SuperSocket.ClientEngine</RootNamespace>
     <AssemblyName>SuperSocket.ClientEngine.Core</AssemblyName>
-    <FileAlignment>512</FileAlignment>
-    <AndroidApplication>true</AndroidApplication>
-    <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
+    <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
+    <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
+    <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
+    <AndroidResgenClass>Resource</AndroidResgenClass>
     <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
+    <TargetFrameworkVersion>v2.3</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -71,7 +71,4 @@
   <Target Name="AfterBuild">
   </Target>
   -->
-  <ItemGroup>
-    <None Include="Properties\AndroidManifest.xml" />
-  </ItemGroup>
 </Project>

--- a/Core/Core.MonoTouch.csproj
+++ b/Core/Core.MonoTouch.csproj
@@ -43,7 +43,6 @@
     </Compile>
     <Compile Include="AsyncTcpSession.cs" />
     <Compile Include="ClientSession.cs" />
-    <Compile Include="ConcurrentQueue.cs" />
     <Compile Include="DataEventArgs.cs" />
     <Compile Include="ErrorEventArgs.cs" />
     <Compile Include="IBufferSetter.cs" />

--- a/Core/Core.iOS.csproj
+++ b/Core/Core.iOS.csproj
@@ -54,7 +54,6 @@
     </Compile>
     <Compile Include="AsyncTcpSession.cs" />
     <Compile Include="ClientSession.cs" />
-    <Compile Include="ConcurrentQueue.cs" />
     <Compile Include="DataEventArgs.cs" />
     <Compile Include="ErrorEventArgs.cs" />
     <Compile Include="IBufferSetter.cs" />

--- a/Core/Properties/AndroidManifest.xml
+++ b/Core/Properties/AndroidManifest.xml
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="Core.MonoDroid">
-	<uses-sdk />
-	<application android:label="Core.MonoDroid"></application>
-</manifest>

--- a/Core/TcpClientSession.cs
+++ b/Core/TcpClientSession.cs
@@ -96,7 +96,7 @@ namespace SuperSocket.ClientEngine
                 throw new Exception("The socket is connecting, cannot connect again!");
 
             if (Client != null)
-                throw new Exception("The socket is connected, you neednt' connect again!");
+                throw new Exception("The socket is connected, you needn't connect again!");
 
             //If there is a proxy set, connect the proxy server by proxy connector
             if (Proxy != null)

--- a/Protocol/Properties/AndroidManifest.xml
+++ b/Protocol/Properties/AndroidManifest.xml
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="Protocol.MonoDroid">
-	<uses-sdk />
-	<application android:label="Protocol.MonoDroid"></application>
-</manifest>

--- a/Protocol/Protocol.MonoDroid.csproj
+++ b/Protocol/Protocol.MonoDroid.csproj
@@ -15,6 +15,7 @@
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <AssemblyName>SuperSocket.ClientEngine.Protocol</AssemblyName>
+    <TargetFrameworkVersion>v2.3</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -25,7 +26,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AndroidLinkMode>None</AndroidLinkMode>
-    <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>full</DebugType>
@@ -35,9 +35,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
-    <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Mono.Android" />
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -56,9 +56,6 @@
     <Compile Include="Properties\AssemblyInfo.MonoDroid.cs" />
     <Compile Include="StringCommandInfo.cs" />
     <Compile Include="DelegateCommand.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Properties\AndroidManifest.xml" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
   <ItemGroup>

--- a/Proxy/Properties/AndroidManifest.xml
+++ b/Proxy/Properties/AndroidManifest.xml
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="Proxy.MonoDroid">
-	<uses-sdk />
-	<application android:label="Proxy.MonoDroid"></application>
-</manifest>

--- a/Proxy/Proxy.MonoDroid.csproj
+++ b/Proxy/Proxy.MonoDroid.csproj
@@ -8,17 +8,14 @@
     <ProjectGuid>{AEFB6063-063D-4124-9DA6-F88350CE0039}</ProjectGuid>
     <ProjectTypeGuids>{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SuperSocket.ClientEngine.Proxy</RootNamespace>
     <AssemblyName>SuperSocket.ClientEngine.Proxy</AssemblyName>
-    <FileAlignment>512</FileAlignment>
-    <AndroidApplication>true</AndroidApplication>
-    <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <AndroidSupportedAbis>armeabi</AndroidSupportedAbis>
-    <AndroidStoreUncompressedFileExtensions />
-    <MandroidI18n />
-    <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
+    <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
+    <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
+    <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
+    <AndroidResgenClass>Resource</AndroidResgenClass>
     <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
+    <TargetFrameworkVersion>v2.3</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -65,9 +62,6 @@
   <Target Name="AfterBuild">
   </Target>
   -->
-  <ItemGroup>
-    <None Include="Properties\AndroidManifest.xml" />
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Common\Common.MonoDroid.csproj">
       <Project>{38367EC0-D72E-4EC5-8FBA-0AE3706A2C49}</Project>


### PR DESCRIPTION
 - Updated the MonoDroid projects to the new format required by Xamarin.Android (they used the same format for libraries as app initially)
 - Using the `<TargetFrameworkVersion>` of Android v2.3 as all previous versions have been dropped by Xamarin
 - The `AndroidManifest.xml` files are only required by Android apps, not libraries
 - Removed `ConcurrentQueue` from the iOS projects as this has now been included in the `mscorlib.dll`
 - Fixed a spelling error in `TclClientSession`

Let me know if you have any questions, I'll be here :)