### PR TITLE
修复new ArraySegment<byte>(e.Data, e.Offset, e.Length)生成的对象都是相同的

### DIFF
--- a/EasyClientBase.cs
+++ b/EasyClientBase.cs
@@ -78,7 +78,10 @@ namespace SuperSocket.ClientEngine
 
         void m_Session_DataReceived(object sender, DataEventArgs e)
         {
-            PipeLineProcessor.Process(new ArraySegment<byte>(e.Data, e.Offset, e.Length), this as IBufferState);
+            //PipeLineProcessor.Process(new ArraySegment<byte>(e.Data, e.Offset, e.Length), this as IBufferState);
+            var buffer = new byte[e.Length - e.Offset];
+            Array.Copy(e.Data, e.Offset, buffer, 0, buffer.Length);
+            PipeLineProcessor.Process(new ArraySegment<byte>(buffer), this as IBufferState);
         }
 
         void m_Session_Error(object sender, ErrorEventArgs e)


### PR DESCRIPTION
new ArraySegment<byte>(e.Data, e.Offset, e.Length)生成的对象都是相同的。当服务端发送的数据块大于ReceiveBufferSize时候会导致后续BufferStream中的中缓存的ArraySegment对象列表都是最后一次接收数据生成的