### PR TITLE
fix NullReferenceException

### DIFF
--- a/EasyClientBase.cs
+++ b/EasyClientBase.cs
@@ -101,8 +101,11 @@ namespace SuperSocket.ClientEngine
         {
             if (!m_Connected)
             {
-                m_ConnectTaskSource.SetResult(false);
-                m_ConnectTaskSource = null;
+                if(m_ConnectTaskSource != null)
+                {
+                    m_ConnectTaskSource.SetResult(false);
+                    m_ConnectTaskSource = null;
+                }
             }
 
             OnError(e);


### PR DESCRIPTION
当客户端连接到服务器一段时间后，客户端发送数据到服务器后在ProcessReceive处理SocketAsyncEventArgs返回的结果为SocketError.Timeout时候会在回调OnError时候出现NullReferenceException