### PR TITLE
Fix the bug about LocalEndPoint of TcpClientSession is always null

### DIFF
--- a/Core/TcpClientSession.cs
+++ b/Core/TcpClientSession.cs
@@ -176,6 +176,7 @@ namespace SuperSocket.ClientEngine
             Client = socket;
 
             m_InConnecting = false;
+			LocalEndPoint = socket.LocalEndPoint;
 
 #if !SILVERLIGHT && !NETFX_CORE
             try


### PR DESCRIPTION
when client connected to the server,set the value of LocalEndpoint