### PR TITLE
fix bug about the value of LocalEndPoint is not set 

### DIFF
--- a/Core/TcpClientSession.cs
+++ b/Core/TcpClientSession.cs
@@ -175,7 +175,11 @@ namespace SuperSocket.ClientEngine
 
             Client = socket;
             m_InConnecting = false;
-			LocalEndPoint = socket.LocalEndPoint;
+
+#if !SILVERLIGHT
+            LocalEndPoint = socket.LocalEndPoint;
+#endif
+
             HostName = GetHostOfEndPoint(socket.RemoteEndPoint);
 
 

--- a/EasyClientBase.cs
+++ b/EasyClientBase.cs
@@ -243,6 +243,15 @@ namespace SuperSocket.ClientEngine
         void m_Session_Connected(object sender, EventArgs e)
         {
             m_Connected = true;
+
+#if !SILVERLIGHT
+            TcpClientSession session = sender as TcpClientSession;
+            if (session != null)
+            {
+                LocalEndPoint = session.LocalEndPoint;
+            }
+#endif
+
             FinishConnectTask(true);
 
             var handler = Connected;


### PR DESCRIPTION
the value of inLocalEndPoint is not set in  EasyClientBase
add condition compile when set the value of  LocalEndPoint in TcpClientSession