### PR TITLE
set the LocalEndPoint to null after raising the closed event

### DIFF
--- a/EasyClientBase.cs
+++ b/EasyClientBase.cs
@@ -287,15 +287,14 @@ namespace SuperSocket.ClientEngine
         {
             m_Connected = false;
 
-
-#if !SILVERLIGHT
-            m_LocalEndPoint = null;
-#endif
-
             var handler = Closed;
 
             if (handler != null)
                 handler(this, EventArgs.Empty);
+
+#if !SILVERLIGHT
+            m_LocalEndPoint = null;
+#endif
 
             var closeTaskSrc = m_CloseTaskSource;
             


### PR DESCRIPTION
when the closed event raised,the caller need to get the LocalEndPoint

