### PR TITLE
Clean up old RemoteEndPoint property from ClientSession.

### DIFF
--- a/Core/ClientSession.cs
+++ b/Core/ClientSession.cs
@@ -13,8 +13,6 @@ namespace SuperSocket.ClientEngine
         
         protected Socket Client { get; set; }
 
-        protected EndPoint RemoteEndPoint { get; set; }
-
 #if !SILVERLIGHT
         public virtual EndPoint LocalEndPoint { get; set; }
 #endif

--- a/Core/TcpClientSession.cs
+++ b/Core/TcpClientSession.cs
@@ -104,7 +104,7 @@ namespace SuperSocket.ClientEngine
             if (Proxy != null)
             {
                 Proxy.Completed += new EventHandler<ProxyEventArgs>(Proxy_Completed);
-                Proxy.Connect(RemoteEndPoint);
+                Proxy.Connect(remoteEndPoint);
                 m_InConnecting = true;
                 return;
             }


### PR DESCRIPTION
There is one usage of RemoteEndPoint left over when 4ae90a56558fa5b042fde9238a31b8e98e536a4d
is done. It  throws ArgumentNullException at line 108 as RemoteEndPoint is always null.