### PR TITLE
allow TLS through an http proxy

### DIFF
--- a/Common/ProxyEventArgs.cs
+++ b/Common/ProxyEventArgs.cs
@@ -7,21 +7,28 @@ namespace SuperSocket.ClientEngine
     public class ProxyEventArgs : EventArgs
     {
         public ProxyEventArgs(Socket socket)
-            : this(true, socket, null)
+            : this(true, socket, null, null)
+        {
+
+        }
+
+        public ProxyEventArgs(Socket socket, string targetHostHame)
+            : this(true, socket, targetHostHame, null)
         {
 
         }
 
         public ProxyEventArgs(Exception exception)
-            : this(false, null, exception)
+            : this(false, null, null, exception)
         {
 
         }
 
-        public ProxyEventArgs(bool connected, Socket socket, Exception exception)
+        public ProxyEventArgs(bool connected, Socket socket, string targetHostName, Exception exception)
         {
             Connected = connected;
             Socket = socket;
+            TargetHostName = targetHostName;
             Exception = exception;
         }
 
@@ -30,5 +37,7 @@ namespace SuperSocket.ClientEngine
         public Socket Socket { get; private set; }
 
         public Exception Exception { get; private set; }
+
+        public string TargetHostName { get; private set; }
     }
 }

--- a/Core/TcpClientSession.cs
+++ b/Core/TcpClientSession.cs
@@ -126,7 +126,13 @@ namespace SuperSocket.ClientEngine
 
             if (e.Connected)
             {
-                ProcessConnect(e.Socket, null, null, null);
+                SocketAsyncEventArgs se = null;
+                if (e.TargetHostName != null)
+                {
+                    se = new SocketAsyncEventArgs();
+                    se.RemoteEndPoint = new DnsEndPoint(e.TargetHostName, 0);
+                }
+                ProcessConnect(e.Socket, null, se, null);
                 return;
             }
 

--- a/Proxy/HttpConnectProxy.cs
+++ b/Proxy/HttpConnectProxy.cs
@@ -44,13 +44,19 @@ namespace SuperSocket.ClientEngine.Proxy
         }
 #else
         public HttpConnectProxy(EndPoint proxyEndPoint)
-            : this(proxyEndPoint, 128)
+            : this(proxyEndPoint, 128, null)
         {
 
         }
 
-        public HttpConnectProxy(EndPoint proxyEndPoint, int receiveBufferSize)
-            : base(proxyEndPoint)
+        public HttpConnectProxy(EndPoint proxyEndPoint, string targetHostName)
+            : this(proxyEndPoint, 128, targetHostName)
+        {
+
+        }
+
+        public HttpConnectProxy(EndPoint proxyEndPoint, int receiveBufferSize, string targetHostName)
+            : base(proxyEndPoint, targetHostName)
         {
             m_ReceiveBufferSize = receiveBufferSize;
         }
@@ -215,7 +221,7 @@ namespace SuperSocket.ClientEngine.Proxy
                 return;
             }
 
-            OnCompleted(new ProxyEventArgs(context.Socket));
+            OnCompleted(new ProxyEventArgs(context.Socket, TargetHostHame));
         }
     }
 }

--- a/Proxy/ProxyConnectorBase.cs
+++ b/Proxy/ProxyConnectorBase.cs
@@ -10,6 +10,8 @@ namespace SuperSocket.ClientEngine.Proxy
     {
         public EndPoint ProxyEndPoint { get; private set; }
 
+        public string TargetHostHame { get; private set; }
+
         protected static Encoding ASCIIEncoding = new ASCIIEncoding();
 
 #if SILVERLIGHT && !WINDOWS_PHONE
@@ -23,8 +25,14 @@ namespace SuperSocket.ClientEngine.Proxy
 
 #else
         public ProxyConnectorBase(EndPoint proxyEndPoint)
+            : this(proxyEndPoint, null)
+        {
+
+        }
+        public ProxyConnectorBase(EndPoint proxyEndPoint, string targetHostHame)
         {
             ProxyEndPoint = proxyEndPoint;
+            TargetHostHame = targetHostHame;
         }
 #endif
 


### PR DESCRIPTION
Currently TLS through an http proxy is broken since the certificate check compares the proxy name to the name in the certificate instead of comparing the target host name to the certificate name.  This change allows the user of the http proxy to specify the target host name for the TLS connection.