### PR TITLE
WIP Fix: partially matched buffer length should be ignored.

### DIFF
--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -111,6 +111,7 @@ namespace SuperSocket.ClientEngine
 
             if (result.Value < 0)
             {
+                searchState.Matched = 0 - result.Value;
                 return -1;
             }
 

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -111,7 +111,6 @@ namespace SuperSocket.ClientEngine
 
             if (result.Value < 0)
             {
-                searchState.Matched = 0 - result.Value;
                 return -1;
             }
 

--- a/Test/HttpConnectProxyTest.cs
+++ b/Test/HttpConnectProxyTest.cs
@@ -1,0 +1,64 @@
+using System.Threading.Tasks;
+using Xunit;
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Collections.Generic;
+using SuperSocket.ProtoBase;
+using System.Text;
+using SuperSocket.ClientEngine.Proxy;
+using System.Threading;
+
+namespace SuperSocket.ClientEngine.Test
+{
+    public class HttpConnectProxyTest
+    {
+        [Fact]
+        public void TestMatchSecondTime()
+        {
+            var server = CreateSimplyRespond(Encoding.ASCII.GetBytes("OK"));
+            var proxyServer = CreateSimplyRespond(Encoding.ASCII.GetBytes("OK"));
+
+            ManualResetEvent wait = new ManualResetEvent(false);
+
+            var proxy = new HttpConnectProxy(proxyServer.LocalEndPoint);
+            ProxyEventArgs eventArgs = null;
+            proxy.Completed += (a, e) =>
+            {
+                eventArgs = e;
+                wait.Set();
+            };
+            proxy.Connect(server.LocalEndPoint);
+
+            Assert.True(wait.WaitOne(5000));
+            Assert.Null(eventArgs.Exception);
+            Assert.True(eventArgs.Connected);
+        }
+
+        Socket CreateSimplyRespond(byte[] data)
+        {
+            var socket = NewTcpLocalBound();
+            Task.Run(
+                () =>
+                {
+                    var stream = socket.Accept();
+                    stream.Send(data);
+                    stream.Shutdown(SocketShutdown.Both);
+                    socket.Dispose();
+                }
+            );
+
+            return socket;
+        }
+
+        Socket NewTcp() => new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+
+        Socket NewTcpLocalBound()
+        {
+            var socket = NewTcp();
+            socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+            socket.Listen(1);
+            return socket;
+        }
+    }
+}

--- a/Test/SearchMarkTest.cs
+++ b/Test/SearchMarkTest.cs
@@ -1,0 +1,78 @@
+using System.Threading.Tasks;
+using Xunit;
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Collections.Generic;
+using SuperSocket.ProtoBase;
+using System.Text;
+
+namespace SuperSocket.ClientEngine.Test
+{
+    public class SearchMarkTest
+    {
+        [Fact]
+        public void TestMatchSecondTime()
+        {
+            byte[] first = Encoding.ASCII.GetBytes("HTTP/1.0 200 Connection Established\r\n");
+            byte[] second = Encoding.ASCII.GetBytes("\r\n");
+
+            byte[] mark = Encoding.ASCII.GetBytes("\r\n\r\n");
+
+            // -2 means "\r\n\r\n" is partially matched at last 2 bytes
+            Assert.Equal(-2, first.SearchMark(0, first.Length, mark));
+
+            // 0 means later part of "\r\n\r\n" is fully matched at 0
+            Assert.Equal(0, second.SearchMark(0, second.Length, mark, 2));
+        }
+
+        [Fact]
+        public void TestMatchFirstTime()
+        {
+            byte[] first = Encoding.ASCII.GetBytes("HTTP/1.0 200 Connection Established\r\n\r\n");
+
+            byte[] mark = Encoding.ASCII.GetBytes("\r\n\r\n");
+
+            // "\r\n\r\n" is matched at first[35] to [38]
+            Assert.Equal(35, first.SearchMark(0, first.Length, mark));
+        }
+
+        [Fact]
+        public void TestMatchFirstTimeWithSearchMarkState()
+        {
+            byte[] first = Encoding.ASCII.GetBytes("HTTP/1.0 200 Connection Established\r\n\r\n");
+
+            byte[] mark = Encoding.ASCII.GetBytes("\r\n\r\n");
+
+            var searchState = new SearchMarkState<byte>(mark);
+
+            // "\r\n\r\n" is matched at first[35] to [38]
+            Assert.Equal(35, first.SearchMark(0, first.Length, searchState));
+        }
+
+        [Fact]
+        public void TestMatchSecondTimeWithSearchMarkState()
+        {
+            byte[] first = Encoding.ASCII.GetBytes("HTTP/1.0 200 Connection Established\r\n");
+            byte[] second = Encoding.ASCII.GetBytes("\r\n");
+
+            byte[] mark = Encoding.ASCII.GetBytes("\r\n\r\n");
+
+            var searchState = new SearchMarkState<byte>(mark);
+
+            {
+                // -1 means: not matched, or partially matched.
+                Assert.Equal(-1, first.SearchMark(0, first.Length, searchState));
+
+                // Check if (1 <= searchState.Matched) in case of partial match.
+            }
+            {
+                var prevMatched = searchState.Matched;
+                Assert.Equal(prevMatched, 2);
+
+                // "\r\n\r\n" is completely matched on second buffer at second[0] to [1].
+                Assert.Equal(0, second.SearchMark(0, second.Length, searchState));
+            }
+        }
+    }
+}


### PR DESCRIPTION
- `"HTTP/1.0 200 Connection Established\r\n"` ← this `"\r\n"` returns context.SearchState.Matched == 2
  `"Proxy-agent: Apache/2.2.29 (Win32)\r\n"`
  `"\r\n\r\n"`

Fix #92 