### PR TITLE
Handling unhanded exception "You cannot set LocalEdnPoint after you start the connection." occurs when connection closed called (By some internal code)

### DIFF
--- a/Core/ClientSession.cs
+++ b/Core/ClientSession.cs
@@ -119,7 +119,14 @@ namespace SuperSocket.ClientEngine
         protected virtual void OnClosed()
         {
             IsConnected = false;
-            LocalEndPoint =  null;
+            try
+            {
+                LocalEndPoint = null;
+            }
+            catch (Exception ex)
+            {
+                OnError(ex);
+            }
 
             var handler = m_Closed;
 


### PR DESCRIPTION
Some time i am getting this exception, below is the stack trace.

System.Exception: You cannot set LocalEdnPoint after you start the connection.
at SuperSocket.ClientEngine.TcpClientSession.set_LocalEndPoint(EndPoint value)
at SuperSocket.ClientEngine.ClientSession.OnClosed()
at SuperSocket.ClientEngine.AuthenticatedStreamTcpSession.OnDataRead(IAsyncResult result)
at System.Net.LazyAsyncResult.Complete(IntPtr userToken)
at System.Net.LazyAsyncResult.ProtectedInvokeCallback(Object result, IntPtr userToken)
at System.Net.AsyncProtocolRequest.CompleteWithError(Exception e)
at System.Net.Security._SslStream.ReadFrameCallback(AsyncProtocolRequest asyncRequest)
at System.Net.AsyncProtocolRequest.CompleteRequest(Int32 result)
at System.Net.FixedSizeReader.CheckCompletionBeforeNextRead(Int32 bytes)
at System.Net.FixedSizeReader.ReadCallback(IAsyncResult transportResult)
at System.Net.LazyAsyncResult.Complete(IntPtr userToken)
at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)
at System.Net.ContextAwareResult.Complete(IntPtr userToken)
at System.Net.LazyAsyncResult.ProtectedInvokeCallback(Object result, IntPtr userToken)
at System.Net.Sockets.BaseOverlappedAsyncResult.CompletionPortCallback(UInt32 errorCode, UInt32 numBytes, NativeOverlapped* nativeOverlapped)
at System.Threading._IOCompletionCallback.PerformIOCompletionCallback(UInt32 errorCode, UInt32 numBytes, NativeOverlapped* pOVERLAP)


@kerryjiang  please have a look on it.